### PR TITLE
Support LoRA alias in OpenAI model field

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -9,7 +9,11 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 from fastapi import HTTPException, Request
 from fastapi.responses import ORJSONResponse, StreamingResponse
 
-from sglang.srt.entrypoints.openai.protocol import ErrorResponse, OpenAIServingRequest
+from sglang.srt.entrypoints.openai.protocol import (
+    DEFAULT_MODEL_NAME,
+    ErrorResponse,
+    OpenAIServingRequest,
+)
 from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.server_args import ServerArgs
 
@@ -39,6 +43,8 @@ class OpenAIServingBase(ABC):
     ) -> Union[Any, StreamingResponse, ErrorResponse]:
         """Handle the specific request type with common pattern"""
         try:
+            await self._apply_lora_alias_if_needed(request)
+
             # Validate request
             error_msg = self._validate_request(request)
             if error_msg:
@@ -75,6 +81,62 @@ class OpenAIServingBase(ABC):
                 err_type="InternalServerError",
                 status_code=500,
             )
+
+    async def _apply_lora_alias_if_needed(
+        self, request: OpenAIServingRequest
+    ) -> None:
+        """Populate ``lora_path`` when clients specify a LoRA via the ``model`` field."""
+
+        if not hasattr(request, "lora_path") or not hasattr(request, "model"):
+            return
+
+        # Respect explicit lora_path values.
+        if getattr(request, "lora_path") is not None:
+            return
+
+        server_args = getattr(self.tokenizer_manager, "server_args", None)
+        if not server_args or not getattr(server_args, "enable_lora", False):
+            return
+
+        requested_model = getattr(request, "model", None)
+        if requested_model in (None, ""):
+            return
+
+        served_names = self._get_served_model_aliases()
+        served_names.add(DEFAULT_MODEL_NAME)
+        if requested_model in served_names:
+            return
+
+        registry = getattr(self.tokenizer_manager, "lora_registry", None)
+        if registry is None or not hasattr(registry, "has_lora"):
+            return
+
+        try:
+            has_lora = await registry.has_lora(requested_model)
+        except Exception:  # pragma: no cover - defensive, should not happen.
+            return
+
+        if has_lora:
+            logger.debug(
+                "Resolved LoRA adapter '%s' from model field", requested_model
+            )
+            setattr(request, "lora_path", requested_model)
+
+    def _get_served_model_aliases(self) -> set[str]:
+        """Return names that should map to the base model."""
+
+        aliases: set[str] = set()
+        served_model = getattr(self.tokenizer_manager, "served_model_name", None)
+        if served_model:
+            aliases.update(
+                name.strip() for name in served_model.split(",") if name.strip()
+            )
+
+        model_path = getattr(self.tokenizer_manager, "model_path", None)
+        if model_path:
+            aliases.add(model_path)
+
+        return aliases
 
     @abstractmethod
     def _request_id_prefix(self) -> str:

--- a/python/sglang/srt/lora/lora_registry.py
+++ b/python/sglang/srt/lora/lora_registry.py
@@ -205,3 +205,9 @@ class LoRARegistry:
         Returns the total number of LoRA adapters currently registered.
         """
         return len(self._registry)
+
+    async def has_lora(self, lora_name: str) -> bool:
+        """Return whether a LoRA adapter with the given name is registered."""
+
+        async with self._registry_lock.reader_lock:
+            return lora_name in self._registry

--- a/test/srt/openai_server/basic/test_serving_chat.py
+++ b/test/srt/openai_server/basic/test_serving_chat.py
@@ -11,7 +11,7 @@ import json
 import unittest
 import uuid
 from typing import Optional
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from fastapi import Request
 
@@ -32,8 +32,12 @@ class _MockTokenizerManager:
             enable_cache_report=False,
             tool_call_parser="hermes",
             reasoning_parser=None,
+            enable_lora=False,
         )
         self.chat_template_name: Optional[str] = "llama-3"
+        self.served_model_name = "base-model"
+        self.model_path = "base-model"
+        self.lora_registry = Mock(has_lora=AsyncMock(return_value=False))
 
         # tokenizer stub
         self.tokenizer = Mock()
@@ -96,6 +100,18 @@ class ServingChatTestCase(unittest.TestCase):
 
         self.fastapi_request = Mock(spec=Request)
         self.fastapi_request.headers = {}
+
+    def test_model_alias_sets_lora_path(self):
+        req = ChatCompletionRequest(
+            model="math-lora",
+            messages=[{"role": "user", "content": "Hi?"}],
+        )
+        self.tm.server_args.enable_lora = True
+        self.tm.lora_registry.has_lora.return_value = True
+
+        asyncio.run(self.chat._apply_lora_alias_if_needed(req))
+
+        self.assertEqual(req.lora_path, "math-lora")
 
     # ------------- conversion tests -------------
     def test_convert_to_internal_request_single(self):

--- a/test/srt/openai_server/basic/test_serving_completions.py
+++ b/test/srt/openai_server/basic/test_serving_completions.py
@@ -4,6 +4,7 @@ Run with:
     python -m unittest tests.test_serving_completions_unit -v
 """
 
+import asyncio
 import unittest
 from typing import Optional
 from unittest.mock import AsyncMock, Mock, patch
@@ -38,7 +39,10 @@ class ServingCompletionTestCase(unittest.TestCase):
         tm.tokenizer.bos_token_id = 1
 
         tm.model_config = Mock(is_multimodal=False)
-        tm.server_args = Mock(enable_cache_report=False)
+        tm.server_args = Mock(enable_cache_report=False, enable_lora=False)
+        tm.served_model_name = "base-model"
+        tm.model_path = "base-model"
+        tm.lora_registry = Mock(has_lora=AsyncMock(return_value=False))
 
         tm.generate_request = AsyncMock()
         tm.create_abort_task = Mock()
@@ -51,6 +55,15 @@ class ServingCompletionTestCase(unittest.TestCase):
         req = CompletionRequest(model="x", prompt="Hello world", max_tokens=100)
         internal, _ = self.sc._convert_to_internal_request(req)
         self.assertEqual(internal.text, "Hello world")
+
+    def test_model_alias_sets_lora_path(self):
+        req = CompletionRequest(model="math-lora", prompt="Hello world")
+        self.sc.tokenizer_manager.server_args.enable_lora = True
+        self.sc.tokenizer_manager.lora_registry.has_lora.return_value = True
+
+        asyncio.run(self.sc._apply_lora_alias_if_needed(req))
+
+        self.assertEqual(req.lora_path, "math-lora")
 
     def test_single_token_ids_prompt(self):
         req = CompletionRequest(model="x", prompt=[1, 2, 3, 4], max_tokens=100)

--- a/test/srt/openai_server/basic/test_serving_embedding.py
+++ b/test/srt/openai_server/basic/test_serving_embedding.py
@@ -4,7 +4,7 @@ Unit tests for the OpenAIServingEmbedding class from serving_embedding.py.
 
 import unittest
 import uuid
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 from fastapi import Request
 
@@ -24,7 +24,10 @@ class _MockTokenizerManager:
         self.model_config.is_multimodal = False
         self.server_args = Mock()
         self.server_args.enable_cache_report = False
+        self.server_args.enable_lora = False
         self.model_path = "test-model"
+        self.served_model_name = "test-model"
+        self.lora_registry = Mock(has_lora=AsyncMock(return_value=False))
 
         # Mock tokenizer
         self.tokenizer = Mock()


### PR DESCRIPTION
## Summary
- map OpenAI `model` aliases to `lora_path` automatically for chat/completions compatibility
- add a helper on `LoRARegistry` to check whether an adapter name is registered
- extend OpenAI serving unit tests with LoRA-aware mocks and coverage for the alias mapping

## Testing
- PYTHONPATH=/workspace/sglang/python pytest test/srt/openai_server/basic/test_serving_chat.py test/srt/openai_server/basic/test_serving_completions.py test/srt/openai_server/basic/test_serving_embedding.py *(fails: sgl_kernel common_ops not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e99a2aed34832e91b435a59acc623a